### PR TITLE
Add createUniqueStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Features](#-features)
-- [Installation](#-installation)
-- [Thanks](#-thanks)
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [createUniqueStore](#createuniquestore)
+- [Thanks](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -26,6 +28,64 @@ Add `wedux` to your project via `npm install`:
 
 ```
 npm install --save @helpscout/wedux
+```
+
+## Usage
+
+Out of the box, Wedux works just like [Unistore](https://github.com/developit/unistore):
+
+```js
+import createStore, {Provider, connect} from '@helpscout/wedux'
+```
+
+### createUniqueStore
+
+This is a special feature that allows you to create stores (with associating `Provider`/`connect` components) with **guaranteed** unique store keys. This is important if you plan on creating **multiple** nested stores. This is especially good for libraries, as it guarantees that the library's Wedux components don't clash with the integrated application Wedux components.
+
+**`createUniqueStore(reducer, enhancer, namespace)`**
+
+| Argument  | Type                | Description                                                            |
+| --------- | ------------------- | ---------------------------------------------------------------------- |
+| reducer   | `Object`/`Function` | Reducer/initialState for the store.                                    |
+| enhancer  | `Object`            | Store enhancer, like `applyMiddleware`.                                |
+| namespace | `string`            | A custom namespace for the store (`context`). It will still be unique. |
+
+**Example**
+
+```jsx
+import {createUniqueStore} from '@helpscout/wedux'
+
+const libStore = createUniqueStore()
+const appStore = createUniqueStore()
+
+const Bob = ({makeBurger}) => <button onClick={makeBurger}>Make Burger</button>
+
+const makeBurger = store => {
+  return {
+    didMakeBurgers: !store.didMakeBurgers,
+  }
+}
+
+const ConnectedBob = libStore.connect(
+  null,
+  {makeBurger},
+)(Bob)
+
+class App extends React.Component {
+  render() {
+    return (
+      <appStore.Provider>
+        <div>
+          ...
+          <libStore.Provider>
+            <ConnectedBob />
+          </libStore.Provider>
+          ...
+        </div>
+      </appStore.Provider>
+    )
+  }
+}
 ```
 
 ## Thanks

--- a/src/__tests__/createUniqueStore.test.tsx
+++ b/src/__tests__/createUniqueStore.test.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+import {mount} from 'enzyme'
+import createUniqueStore from '../createUniqueStore'
+
+test('Generates a store, connect, and Provider', () => {
+  const store = createUniqueStore({})
+
+  expect(store.store).toBeTruthy()
+  expect(store.Provider).toBeTruthy()
+  expect(store.connect).toBeTruthy()
+})
+
+test('Generates components with unique store keys', () => {
+  const storeOne = createUniqueStore({})
+  const storeTwo = createUniqueStore({})
+  const storeThree = createUniqueStore({})
+
+  const keyOne = Object.keys(storeOne.Provider.childContextTypes)[0]
+  const keyTwo = Object.keys(storeTwo.Provider.childContextTypes)[0]
+  const keyThree = Object.keys(storeThree.Provider.childContextTypes)[0]
+
+  expect(keyOne).not.toBe(keyTwo)
+  expect(keyOne).not.toBe(keyThree)
+  expect(keyTwo).not.toBe(keyThree)
+})
+
+test('Can generate a store with a custom namespace', () => {
+  const store = createUniqueStore({}, null, 'Teddy')
+
+  expect(store.store).toBeTruthy()
+  expect(store.Provider).toBeTruthy()
+  expect(store.connect).toBeTruthy()
+
+  const storeKey = Object.keys(store.Provider.childContextTypes)[0]
+
+  expect(storeKey).toContain('Teddy')
+})
+
+test('Rendered components do not clash', () => {
+  const setOne = createUniqueStore({didMakeBurgers: false})
+  const setTwo = createUniqueStore({didMakeBurgers: false})
+
+  const Bob = ({makeBurger}) => (
+    <button onClick={makeBurger}>Make Burger</button>
+  )
+
+  const makeBurger = store => {
+    return {
+      didMakeBurgers: !store.didMakeBurgers,
+    }
+  }
+
+  const ConnectedBob = setTwo.connect(
+    null,
+    {makeBurger},
+  )(Bob)
+
+  const wrapper = mount(
+    <div>
+      <setOne.Provider>
+        <div>
+          <setTwo.Provider>
+            <ConnectedBob />
+          </setTwo.Provider>
+        </div>
+      </setOne.Provider>
+    </div>,
+  )
+
+  const el = wrapper.find('Bob')
+  el.simulate('click')
+
+  expect(setOne.store.getState().didMakeBurgers).toBe(false)
+  expect(setTwo.store.getState().didMakeBurgers).toBe(true)
+
+  el.simulate('click')
+
+  expect(setOne.store.getState().didMakeBurgers).toBe(false)
+  expect(setTwo.store.getState().didMakeBurgers).toBe(false)
+})

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -5,6 +5,7 @@ export type Options = {
   pure: boolean
   withStore: boolean
   store?: any
+  storeKey?: string
 }
 
 const defaultOptions = {
@@ -18,13 +19,15 @@ export function createConnect(
   mergedProps: Object = {},
   options: any = defaultOptions,
 ): any {
-  const {pure, withStore, store: providedStore} = {
+  const {pure, withStore, store: providedStore, storeKey} = {
     ...defaultOptions,
     ...options,
   } as Options
   if (!isFn(mapStateToProps)) {
     mapStateToProps = select(mapStateToProps || [])
   }
+
+  const internalStoreKey = storeKey || defaultStoreKey
 
   const OuterBaseComponent = pure ? React.PureComponent : React.Component
 
@@ -34,7 +37,7 @@ export function createConnect(
     function Wrapper(props, context) {
       OuterBaseComponent.call(this, props, context)
 
-      const store = providedStore || context[defaultStoreKey]
+      const store = providedStore || context[internalStoreKey]
       const boundActions = actions ? mapActions(actions, store) : {store}
 
       let state = mapStateToProps(store ? store.getState() : {}, props)

--- a/src/createProvider.ts
+++ b/src/createProvider.ts
@@ -1,19 +1,27 @@
 import * as React from 'react'
 import {defaultStoreKey} from './utils'
 
-const defaultOptions = {
-  storeKey: defaultStoreKey,
+type ProviderOptions = {
+  storeKey?: string
+  store?: any
 }
 
-export default function createProvider(options = defaultOptions) {
-  const {storeKey} = {...defaultOptions, ...options}
+const defaultOptions = {
+  storeKey: defaultStoreKey,
+  store: undefined,
+}
+
+export default function createProvider(
+  options: ProviderOptions = defaultOptions,
+) {
+  const {storeKey, store} = {...defaultOptions, ...options}
 
   return class Provider extends React.Component<any> {
     static childContextTypes = {
       [storeKey]: () => {},
     }
     getChildContext() {
-      return {[storeKey]: this.props.store}
+      return {[storeKey]: this.props.store || store}
     }
     render() {
       return React.Children.only(this.props.children)

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -1,7 +1,7 @@
 import createUnistore from './createUnistore'
 import {isFn} from './utils'
 
-export default function createStore(reducer, enhancer?) {
+export default function createStore(reducer?, enhancer?) {
   if (enhancer) {
     return enhancer(createStore)(reducer)
   }

--- a/src/createUniqueStore.ts
+++ b/src/createUniqueStore.ts
@@ -1,0 +1,31 @@
+import createStore from './createStore'
+import {uuid} from './utils'
+import createProvider from './createProvider'
+import connect from './connect'
+
+function createUniqueStore(reducer?, enhancer?, namespace?: string) {
+  const store = createStore(reducer, enhancer)
+  const storeKey = uuid(namespace)
+
+  function uniqueConnect(
+    mapStateToProps: any = null,
+    actions: any = null,
+    mergedProps: Object = {},
+    options: any = {},
+  ) {
+    return connect(
+      mapStateToProps,
+      actions,
+      mergedProps,
+      {...options, store},
+    )
+  }
+
+  return {
+    store,
+    Provider: createProvider({storeKey}),
+    connect: uniqueConnect,
+  }
+}
+
+export default createUniqueStore

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {default as applyMiddleware} from './applyMiddleware'
 export {default as combineReducers} from './combineReducers'
 export {default as connect} from './connect'
 export {default as connectWithStore} from './connectWithStore'
+export {default as createUniqueStore} from './createUniqueStore'
 export {default as createProvider} from './connectWithStore'
 export {default as Provider} from './Provider'
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,14 @@
 export const defaultStoreKey = '__WEDUX_STORE__'
 
+export function createUUIDFactory() {
+  let index = 0
+  return (namespace: string = defaultStoreKey): string => {
+    return `${namespace}${index++}__`
+  }
+}
+
+export const uuid = createUUIDFactory()
+
 export function isFn(obj) {
   return typeof obj === 'function'
 }


### PR DESCRIPTION
### createUniqueStore

This is a special feature that allows you to create stores (with associating `Provider`/`connect` components) with **guaranteed** unique store keys. This is important if you plan on creating **multiple** nested stores. This is especially good for libraries, as it guarantees that the library's Wedux components don't clash with the integrated application Wedux components.

**`createUniqueStore(reducer, enhancer, namespace)`**

| Argument  | Type                | Description                                                            |
| --------- | ------------------- | ---------------------------------------------------------------------- |
| reducer   | `Object`/`Function` | Reducer/initialState for the store.                                    |
| enhancer  | `Object`            | Store enhancer, like `applyMiddleware`.                                |
| namespace | `string`            | A custom namespace for the store (`context`). It will still be unique. |

**Example**

```jsx
import {createUniqueStore} from '@helpscout/wedux'

const libStore = createUniqueStore()
const appStore = createUniqueStore()

const Bob = ({makeBurger}) => <button onClick={makeBurger}>Make Burger</button>

const makeBurger = store => {
  return {
    didMakeBurgers: !store.didMakeBurgers,
  }
}

const ConnectedBob = libStore.connect(
  null,
  {makeBurger},
)(Bob)

class App extends React.Component {
  render() {
    return (
      <appStore.Provider>
        <div>
          ...
          <libStore.Provider>
            <ConnectedBob />
          </libStore.Provider>
          ...
        </div>
      </appStore.Provider>
    )
  }
}
```